### PR TITLE
Bug fixed for the last option's drop down portion, Made it's position correctly aligned.

### DIFF
--- a/lib/hover_menu_lastitem.dart
+++ b/lib/hover_menu_lastitem.dart
@@ -5,12 +5,12 @@ The dropdown position starts from the
 remaining screen portion and end exactly where the option item name ends.
  */
 import 'package:flutter/material.dart';
-class HoverMenu1 extends StatefulWidget {
+class HoverMenuLastItem extends StatefulWidget {
   final Widget title;
   final double? width;
   final List<Widget> items;
 
-  const HoverMenu1({
+  const HoverMenuLastItem({
     Key? key,
     required this.title,
     this.items = const [],
@@ -18,10 +18,10 @@ class HoverMenu1 extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  HoverMenu1State createState() => HoverMenu1State();
+  HoverMenuLastItemState createState() => HoverMenuLastItemState();
 }
 
-class HoverMenu1State extends State<HoverMenu1> {
+class HoverMenuLastItemState extends State<HoverMenuLastItem> {
   OverlayEntry? _overlayEntry;
   final _focusNode = FocusNode();
   bool _isHovered = false;

--- a/lib/hover_menu_lastitem.dart
+++ b/lib/hover_menu_lastitem.dart
@@ -1,0 +1,101 @@
+
+
+/* A new file for the last menu option to make it's drop down position not go beyond screen size.
+The dropdown position starts from the
+remaining screen portion and end exactly where the option item name ends.
+ */
+import 'package:flutter/material.dart';
+class HoverMenu1 extends StatefulWidget {
+  final Widget title;
+  final double? width;
+  final List<Widget> items;
+
+  const HoverMenu1({
+    Key? key,
+    required this.title,
+    this.items = const [],
+    this.width,
+  }) : super(key: key);
+
+  @override
+  HoverMenu1State createState() => HoverMenu1State();
+}
+
+class HoverMenu1State extends State<HoverMenu1> {
+  OverlayEntry? _overlayEntry;
+  final _focusNode = FocusNode();
+  bool _isHovered = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode.addListener(_onFocusChanged);
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _onFocusChanged() {
+    if (_focusNode.hasFocus) {
+      _overlayEntry = _createOverlayEntry();
+      Overlay.of(context).insert(_overlayEntry!);
+    } else {
+      _overlayEntry?.remove();
+      _removeOverlay();
+    }
+  }
+
+  void _removeOverlay() {
+    _isHovered = false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      focusNode: _focusNode,
+      onHover: (isHovered) {
+        if (isHovered && !_isHovered) {
+          _focusNode.requestFocus();
+          _isHovered = true;
+        }
+      },
+      onPressed: () {},
+      child: widget.title,
+    );
+  }
+
+  OverlayEntry _createOverlayEntry() {
+    final renderBox = context.findRenderObject() as RenderBox;
+    final size = renderBox.size;
+    final offset = renderBox.localToGlobal(Offset.zero);
+
+    return OverlayEntry(
+      maintainState: true,
+      builder: (context) => Positioned(
+        right: offset.dy-size.width,
+        top: offset.dy + size.height,
+        width: widget.width ?? 200,
+        child: TextButton(
+          onPressed: () {},
+          onHover: (isHovered) {
+            if (isHovered && _isHovered) {
+              _focusNode.requestFocus();
+            } else {
+              _focusNode.unfocus();
+            }
+          },
+          child: Container(
+            child: ListView(
+              padding: EdgeInsets.zero,
+              shrinkWrap: true,
+              children: widget.items,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Made a new file it mainly helps when we need to make the dropdown sceen for a menu item which is the last menu item and the drop down goes out if the screen. The dropdown portion basically overflows beyond the screen 

for eg ;  If we have 5 menu items and it is horizontally aligned and when we want to give the drop down items for the last menu option the drop down size goes out of the screen.
So I am Solving this bug and the drop down portion ends exactly where the menu option ends and it will stretch towards the other side.
The user can call the new class specially for the last menu option..

As you can see in the screenshot the last menu item's drop down position was going outside the screen boundaries and I fixed it by positioning just for the last menu option.
![Screenshot 2023-11-14 102950](https://github.com/doonfrs/hover_menu/assets/106680015/52f3ce13-cfcf-410c-b8bd-58555644f6d9)
